### PR TITLE
Add Tweets With Rake Seed Option

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,8 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'
+  # Seed the database with some information of tweets and users
+  gem 'seedbank'
 
   # Access an IRB console on exception pages or by using <%= console %> in views
   gem 'web-console', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,6 +113,7 @@ GEM
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
+    seedbank (0.3.0)
     spring (1.3.6)
     sprockets (3.2.0)
       rack (~> 1.0)
@@ -148,6 +149,7 @@ DEPENDENCIES
   rails (= 4.2.1)
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
+  seedbank
   spring
   sqlite3
   turbolinks

--- a/db/seeds/development/tweet.seeds.rb
+++ b/db/seeds/development/tweet.seeds.rb
@@ -1,0 +1,9 @@
+%w(widow tommy sam silly).each do |user|
+  user = User.find_or_initialize_by(username: user)
+  user.save!
+  (1..3).each do |tweets|
+    tweet = Tweet.create(text: %q(Flank capicola swine landjaeger ball tip short ribs salami pig boudin pork belly pork loin jerky tongue corned beef meatball.))
+    user.tweets << tweet
+    tweet.save!
+  end
+end


### PR DESCRIPTION
When someone new pulls the repository down, allow them to run the
following rake command: rake db:seed:development:tweet to populate their
database with a few tweets and users so they can see how the system
works immediately.
