### PR TITLE
Refactor The Way Tweet Urls Are Created

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,11 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+  skip_before_action :verify_authenticity_token, if: :json_request?
+
+  private
+
+  def json_request?
+     request.format.json?
+  end
 end

--- a/app/controllers/streams_controller.rb
+++ b/app/controllers/streams_controller.rb
@@ -1,0 +1,5 @@
+class StreamsController < ApplicationController
+  def index
+    @tweets = Tweet.all
+  end
+end

--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -1,23 +1,19 @@
 class TweetsController < ApplicationController
-  def show_for_user
-    @user = User.find(params[:id])
+  def index
+    @user = User.find(params[:user_id])
     @tweets = @user.tweets
-
-    respond_to do |format|
-      format.html
-      format.json { render :json => @tweets.to_json }
-    end
   end
 
   def create
-    @user = User.find(params[:id])
-    @tweet = Tweet.new(params[:tweet])
+    @user = User.find(params[:user_id])
+    @tweet = Tweet.new(tweet_params)
     @tweet.user = @user
-    @tweet.save
+    @tweet.save!
+  end
 
-    respond_to do |format|
-      format.html
-      format.json { render :json => @tweet.to_json }
-    end
+  private
+
+  def tweet_params
+    params.require(:tweet).permit(:text)
   end
 end

--- a/app/views/streams/index.json.jbuilder
+++ b/app/views/streams/index.json.jbuilder
@@ -1,0 +1,9 @@
+json.array! @tweets do |tweet|
+  json.text tweet.text
+  json.created_at tweet.created_at
+  json.updated_at tweet.updated_at
+  json.author do
+    json.username tweet.user.username
+    json.user_id tweet.user.id
+  end
+end

--- a/app/views/tweets/_tweet.html.erb
+++ b/app/views/tweets/_tweet.html.erb
@@ -1,1 +1,0 @@
-Tweet: <%= tweet.text %>

--- a/app/views/tweets/create.json.jbuilder
+++ b/app/views/tweets/create.json.jbuilder
@@ -1,0 +1,3 @@
+json.tweet do
+  json.text @tweet.text
+end

--- a/app/views/tweets/index.json.jbuilder
+++ b/app/views/tweets/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @tweets, :text, :created_at, :updated_at

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,11 +3,9 @@ Rails.application.routes.draw do
   root 'users#index'
 
   resources :users do
-    member do
-      get 'tweets' => 'tweets#show_for_user'
-      post 'tweets' => 'tweets#create'
-    end
+    resources :tweets, only: [:index, :create]
   end
+  get '/tweets', to: 'streams#index', as: :tweets_index
 
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".


### PR DESCRIPTION
Refactor the tweets endpoint to be more rails and rest like. No longer
do we rely in on a special named route like user_tweets. Rely only on
restful routing methods like (index, get, patch, post, etc). Rails 4.2
no longer requires the respond_to or respond_with blocks. In fact,
respond_with has been deprecated to a separate gem. Catch the instance
variables created in each route and pass them to jbuilder templates that
will correctly format the json output for each route.
